### PR TITLE
End of development notice +1

### DIFF
--- a/src/rtpselect.h
+++ b/src/rtpselect.h
@@ -87,6 +87,11 @@ inline int RTPSelect(const SocketType *sockets, int8_t *readflags, size_t numsoc
 		return ERR_RTP_SELECT_ERRORINPOLL;
 #else
 	int status = poll(&(fds[0]), numsocks, timeoutmsec);
+	if (fds[0].revents == POLLNVAL)
+	{
+		printf("Hey, the file descriptor %d was closed. You are doing something wrong. Best, Aleks, Chase, Eric, and Kunal\n", fds[0].fd);
+		return ERR_RTP_SELECT_ERRORINPOLL;
+	}
 	if (status < 0)
 	{
 		// We're just going to ignore an EINTR


### PR DESCRIPTION
The Mighty host was accidentally closing a reference to the same file descriptor twice in the `encoder_process`. The second time it would close an FD that JRTPLib was using to send/listen to data. If the FD that JRTPLib was using is closed unexpectedly, then the library will poll the FD and get stuck in an infinite loop since it won't check for the FD being closed.

This PR checks that and returns an error if the FD is closed. The double-closing FD problem was resolved in this PR https://github.com/mightyapp/cloudbox/pull/1894/files